### PR TITLE
fix: fix model name not included user name when create model

### DIFF
--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -286,7 +286,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
             });
 
             if (operationIsDone) {
-              const modelName = `models/${modelId.trim()}`;
+              const modelName = `${user.data.name}/models/${modelId.trim()}`;
               const modelState = await watchUserModel({
                 modelName,
                 accessToken,


### PR DESCRIPTION
Because

- Backend had supported name space

This commit

- fix model name not included user name when create model
