### PR TITLE
fix(toolkit): fix pipeline-builder wrongly request backend for pipelineReleases

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.0-rc.44",
+  "version": "0.68.0-rc.45",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/BottomBar.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/BottomBar.tsx
@@ -4,21 +4,33 @@ import {
   getHumanReadableStringFromTime,
   useUserPipelineReleases,
 } from "../../../lib";
-import { usePipelineBuilderStore } from "../usePipelineBuilderStore";
+import {
+  PipelineBuilderStore,
+  usePipelineBuilderStore,
+} from "../usePipelineBuilderStore";
+import { shallow } from "zustand/shallow";
 
 export type BottomBarProps = {
   enableQuery: boolean;
   accessToken: Nullable<string>;
 };
 
+const pipelineBuilderSelector = (state: PipelineBuilderStore) => ({
+  pipelineName: state.pipelineName,
+  pipelineIsNew: state.pipelineIsNew,
+});
+
 export const BottomBar = (props: BottomBarProps) => {
   const { enableQuery, accessToken } = props;
 
-  const pipelineName = usePipelineBuilderStore((state) => state.pipelineName);
+  const { pipelineIsNew, pipelineName } = usePipelineBuilderStore(
+    pipelineBuilderSelector,
+    shallow
+  );
 
   const pipelineReleases = useUserPipelineReleases({
     pipelineName,
-    enabled: enableQuery,
+    enabled: pipelineIsNew ? false : enableQuery,
     accessToken,
   });
 


### PR DESCRIPTION
Because

- When the pipeline is new we should not query its pipelineRelease

This commit

- fix pipeline-builder wrongly request backend for pipelineReleases
