### PR TITLE
feat(toolkit): when user delete the full pipeline name and blur out we recover the form with previous name

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.0-rc.51",
+  "version": "0.68.0-rc.55",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/PipelineNameForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/PipelineNameForm.tsx
@@ -40,7 +40,7 @@ export type PipelineNameFormProps = {
 };
 
 export const UpdatePipelineIdSchema = z.object({
-  pipelineId: z.string().min(1, { message: "Pipeline ID is required" }),
+  pipelineId: z.string().nullable().optional(),
 });
 
 export const PipelineNameForm = (props: PipelineNameFormProps) => {
@@ -73,7 +73,6 @@ export const PipelineNameForm = (props: PipelineNameFormProps) => {
     pipelineRecipeIsDirty,
   } = usePipelineBuilderStore(pipelineBuilderSelector, shallow);
 
-  // Disable edit on the topbar
   React.useEffect(() => {
     form.reset({
       pipelineId: router.asPath.split("/")[2],
@@ -213,6 +212,14 @@ export const PipelineNameForm = (props: PipelineNameFormProps) => {
                       autoComplete="off"
                       onBlur={() => {
                         form.handleSubmit(async (data) => {
+                          if (!data.pipelineId || data.pipelineId === "") {
+                            form.reset({
+                              pipelineId:
+                                pipelineId ?? router.asPath.split("/")[2],
+                            });
+                            return;
+                          }
+
                           if (data.pipelineId && isDirty) {
                             await handleRenamePipeline(data.pipelineId);
                           }
@@ -225,6 +232,14 @@ export const PipelineNameForm = (props: PipelineNameFormProps) => {
                           e.preventDefault();
                           e.stopPropagation();
                           form.handleSubmit(async (data) => {
+                            if (!data.pipelineId || data.pipelineId === "") {
+                              form.reset({
+                                pipelineId:
+                                  pipelineId ?? router.asPath.split("/")[2],
+                              });
+                              return;
+                            }
+
                             if (data.pipelineId && isDirty) {
                               await handleRenamePipeline(data.pipelineId);
                             }


### PR DESCRIPTION
Because

- For better UX

This commit

- when user delete the full pipeline name and blur out we recover the form with previous name
