### PR TITLE
fix(design-system): expose the classname of Dialog.Close

### DIFF
--- a/packages/design-system/src/new-ui/Dialog/Dialog.tsx
+++ b/packages/design-system/src/new-ui/Dialog/Dialog.tsx
@@ -60,11 +60,14 @@ DialogContent.displayName = DialogPrimitive.Content.displayName;
 const DialogClose = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Close>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>
->((props, ref) => (
+>(({ className, ...props }, ref) => (
   <DialogPrimitive.Close
     {...props}
     ref={ref}
-    className="absolute right-4 top-4 rounded opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-semantic-accent-hover focus:ring-offset-2 disabled:pointer-events-none"
+    className={cn(
+      "absolute right-4 top-4 rounded opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-semantic-accent-hover focus:ring-offset-2 disabled:pointer-events-none",
+      className
+    )}
   >
     <Icons.X className="h-5 w-5 stroke-semantic-fg-primary" />
     <span className="sr-only">Close</span>


### PR DESCRIPTION
Because

- improve DX

This commit

- expose the classname of Dialog.Close
