### PR TITLE
chore: remove the initial style of Tabs

### DIFF
--- a/packages/design-system/src/new-ui/Tabs/Tabs.tsx
+++ b/packages/design-system/src/new-ui/Tabs/Tabs.tsx
@@ -3,7 +3,6 @@
 // We don't have a unified Tab design yes so we don't have default style here
 // Please refer to the design-docs in Figma for more details.
 
-import cn from "clsx";
 import * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 
@@ -21,15 +20,7 @@ const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "rounded-t-sm border border-semantic-bg-line bg-semantic-bg-base-bg px-3 py-1.5 text-[#1D2433] text-opacity-80 product-body-text-3-semibold",
-      "data-[state=active]:bg-semantic-bg-primary data-[state=active]:text-opacity-100",
-      className
-    )}
-    {...props}
-  />
+  <TabsPrimitive.Trigger ref={ref} className={className} {...props} />
 ));
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
@@ -37,14 +28,7 @@ const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "h-full w-full rounded-sm border border-semantic-bg-line bg-semantic-accent-bg p-2",
-      className
-    )}
-    {...props}
-  />
+  <TabsPrimitive.Content ref={ref} className={className} {...props} />
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 


### PR DESCRIPTION
Because

- To make the implementation clear

This commit

- remove the initial style of Tabs
