### PR TITLE
fix(toolkit): fix delete resource dialog is too wide

### DIFF
--- a/packages/toolkit/src/view/pipeline/PipelinesTable.tsx
+++ b/packages/toolkit/src/view/pipeline/PipelinesTable.tsx
@@ -132,7 +132,7 @@ export const PipelinesTable = (props: PipelinesTableProps) => {
                   Delete
                 </div>
               </Dialog.Trigger>
-              <Dialog.Content>
+              <Dialog.Content className="!w-[512px]">
                 <GeneralDeleteResourceModal
                   resource={row.original}
                   handleDeleteResource={handleDeletePipeline}

--- a/packages/toolkit/src/view/resource/ResourcesTable.tsx
+++ b/packages/toolkit/src/view/resource/ResourcesTable.tsx
@@ -156,7 +156,7 @@ export const ResourcesTable = (props: ResourcesTableProps) => {
                   Delete
                 </div>
               </Dialog.Trigger>
-              <Dialog.Content>
+              <Dialog.Content className="!w-[512px]">
                 <GeneralDeleteResourceModal
                   resource={row.original}
                   handleDeleteResource={handleDeleteUserConnectorResource}


### PR DESCRIPTION
Because

- delete resource dialog is too wide

This commit

- fix delete resource dialog is too wide
