### PR TITLE
feat(toolkit): expose namespace on modelHubDetailsPage

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.0-rc.168",
+  "version": "0.68.0-rc.169",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/model/ModelHubSettingPageMainView.tsx
+++ b/packages/toolkit/src/view/model/ModelHubSettingPageMainView.tsx
@@ -18,12 +18,14 @@ import { ModelConfigurationFields } from "./ModelConfigurationFields";
 
 export type ModelHubSettingPageMainViewProps = GeneralPageProp & {
   modelReadme: ReactElement;
+  modelNamespace: string;
 };
 
 export const ModelHubSettingPageMainView = (
   props: ModelHubSettingPageMainViewProps
 ) => {
-  const { accessToken, enableQuery, router, modelReadme } = props;
+  const { accessToken, enableQuery, router, modelReadme, modelNamespace } =
+    props;
   const { id, entity } = router.query;
 
   /* -------------------------------------------------------------------------
@@ -31,13 +33,13 @@ export const ModelHubSettingPageMainView = (
    * -----------------------------------------------------------------------*/
 
   const model = useUserModel({
-    modelName: id ? `users/instill-ai/models/${id.toString()}` : null,
+    modelName: id ? `users/${modelNamespace}/models/${id.toString()}` : null,
     enabled: enableQuery,
     accessToken,
   });
 
   const modelWatchState = useWatchUserModel({
-    modelName: id ? `users/instill-ai/models/${id.toString()}` : null,
+    modelName: id ? `users/${modelNamespace}/models/${id.toString()}` : null,
     enabled: enableQuery,
     accessToken,
   });


### PR DESCRIPTION
Because

- to better improve flexiblity

This commit

- expose namespace on modelHubDetailsPage
