### PR TITLE
feat: user can identify the node's name editor and pipeline name's editor when focus on the input

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.0-rc.189",
+  "version": "0.68.0-rc.190",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/ConnectorNode/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ConnectorNode/ConnectorNode.tsx
@@ -344,7 +344,7 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
                     return (
                       <input
                         {...field}
-                        className="flex flex-shrink bg-transparent p-1 text-semantic-fg-secondary product-body-text-4-medium focus:outline-none focus:ring-0"
+                        className="flex flex-shrink bg-transparent p-1 text-semantic-fg-secondary product-body-text-4-medium focus:!ring-1 focus:!ring-semantic-accent-default"
                         ref={connectorNameEditInputRef}
                         value={field.value}
                         type="text"

--- a/packages/toolkit/src/view/pipeline-builder/components/PipelineNameForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/PipelineNameForm.tsx
@@ -211,7 +211,7 @@ export const PipelineNameForm = (props: PipelineNameFormProps) => {
                     <input
                       {...field}
                       ref={pipelineNameRef}
-                      className="max-w-[360px] flex-shrink bg-transparent py-2 text-semantic-fg-primary product-body-text-3-semibold focus:outline-none focus:ring-0"
+                      className="max-w-[360px] flex-shrink bg-transparent py-2 text-semantic-fg-primary product-body-text-3-semibold focus:!ring-1 focus:!ring-semantic-accent-default"
                       value={field.value ?? "Untitled Pipeline"}
                       type="text"
                       autoComplete="off"


### PR DESCRIPTION
Because

- Improve UX

This commit

- User can identify the node's name editor and pipeline name's editor when focus on the input
