### PR TITLE
feat(pipeline-builder): user wont get confused by handler if there has no edge on it

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.0-rc.190",
+  "version": "0.68.0-rc.194",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.0-rc.194",
+  "version": "0.68.0-rc.195",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/ConnectorNode/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ConnectorNode/ConnectorNode.tsx
@@ -44,6 +44,7 @@ const pipelineBuilderSelector = (state: PipelineBuilderStore) => ({
   selectedConnectorNodeId: state.selectedConnectorNodeId,
   updateSelectedConnectorNodeId: state.updateSelectedConnectorNodeId,
   nodes: state.nodes,
+  edges: state.edges,
   updateNodes: state.updateNodes,
   updateEdges: state.updateEdges,
   testModeEnabled: state.testModeEnabled,
@@ -69,6 +70,7 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
     selectedConnectorNodeId,
     updateSelectedConnectorNodeId,
     nodes,
+    edges,
     updateNodes,
     updateEdges,
     testModeEnabled,
@@ -311,6 +313,14 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
     data.component,
     testModeTriggerResponse?.metadata?.traces ?? null
   );
+
+  const hasTargetEdges = React.useMemo(() => {
+    return edges.some((edge) => edge.target === id);
+  }, [edges]);
+
+  const hasSourceEdges = React.useMemo(() => {
+    return edges.some((edge) => edge.source === id);
+  }, [edges]);
 
   return (
     <>
@@ -872,8 +882,18 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
           </>
         )}
       </div>
-      <CustomHandle type="target" position={Position.Left} id={id} />
-      <CustomHandle type="source" position={Position.Right} id={id} />
+      <CustomHandle
+        className={hasTargetEdges ? "" : "!opacity-0"}
+        type="target"
+        position={Position.Left}
+        id={id}
+      />
+      <CustomHandle
+        className={hasSourceEdges ? "" : "!opacity-0"}
+        type="source"
+        position={Position.Right}
+        id={id}
+      />
     </>
   );
 };

--- a/packages/toolkit/src/view/pipeline-builder/components/EndNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/EndNode.tsx
@@ -54,6 +54,7 @@ export const EndNode = ({ data, id }: NodeProps<EndNodeData>) => {
 
   const {
     nodes,
+    edges,
     updateNodes,
     updateEdges,
     testModeEnabled,
@@ -173,6 +174,10 @@ export const EndNode = ({ data, id }: NodeProps<EndNodeData>) => {
     pipelineOpenAPISchema,
     testModeTriggerResponse ? testModeTriggerResponse.outputs : []
   );
+
+  const hasTargetEdges = React.useMemo(() => {
+    return edges.some((edge) => edge.target === id);
+  }, [edges]);
 
   return (
     <>
@@ -366,7 +371,12 @@ export const EndNode = ({ data, id }: NodeProps<EndNodeData>) => {
           </div>
         )}
       </div>
-      <CustomHandle type="target" position={Position.Left} id={id} />
+      <CustomHandle
+        className={hasTargetEdges ? "" : "!opacity-0"}
+        type="target"
+        position={Position.Left}
+        id={id}
+      />
     </>
   );
 };

--- a/packages/toolkit/src/view/pipeline-builder/components/StartNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/StartNode.tsx
@@ -49,6 +49,7 @@ const pipelineBuilderSelector = (state: PipelineBuilderStore) => ({
   pipelineIsNew: state.pipelineIsNew,
   pipelineName: state.pipelineName,
   nodes: state.nodes,
+  edges: state.edges,
   updateNodes: state.updateNodes,
   updateEdges: state.updateEdges,
   testModeEnabled: state.testModeEnabled,
@@ -71,6 +72,7 @@ export const StartNode = ({ data, id }: NodeProps<StartNodeData>) => {
   const {
     pipelineName,
     nodes,
+    edges,
     updateNodes,
     updateEdges,
     testModeEnabled,
@@ -303,6 +305,10 @@ export const StartNode = ({ data, id }: NodeProps<StartNodeData>) => {
       return finalType;
     });
   };
+
+  const hasSourceEdges = React.useMemo(() => {
+    return edges.some((edge) => edge.source === id);
+  }, [edges]);
 
   return (
     <>
@@ -650,7 +656,12 @@ export const StartNode = ({ data, id }: NodeProps<StartNodeData>) => {
           </div>
         )}
       </div>
-      <CustomHandle type="source" position={Position.Right} id={id} />
+      <CustomHandle
+        className={hasSourceEdges ? "" : "!opacity-0"}
+        type="source"
+        position={Position.Right}
+        id={id}
+      />
     </>
   );
 };


### PR DESCRIPTION
Because

- improve UX

This commit

- user wont get confused by handler if there has no edge on it
