### PR TITLE
fix: fix user can not filter their existing resource when create resource directly on pipeline builder

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.0",
+  "version": "0.68.1-rc.1",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/ConnectorNode/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ConnectorNode/ConnectorNode.tsx
@@ -683,6 +683,8 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
                           });
                         });
 
+                        updatePipelineRecipeIsDirty(() => true);
+
                         updateCreateResourceDialogState(() => ({
                           open: false,
                           connectorType: null,

--- a/packages/toolkit/src/view/pipeline-builder/components/CreateResourceDialog.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/CreateResourceDialog.tsx
@@ -46,14 +46,19 @@ export const CreateResourceDialog = (props: CreateResourceDialogProps) => {
   });
 
   const filteredConnectors = React.useMemo(() => {
-    if (!existedConnectors.isSuccess) {
+    if (!existedConnectors.isSuccess || !connectorDefinition) {
       return [];
     }
 
     return existedConnectors.data.filter(
-      (connector) => connector.connector_definition.type === connectorType
+      (connector) =>
+        connector.connector_definition.id === connectorDefinition.id
     );
-  }, [existedConnectors.data, existedConnectors.isSuccess, connectorType]);
+  }, [
+    existedConnectors.data,
+    existedConnectors.isSuccess,
+    connectorDefinition,
+  ]);
 
   return (
     <Dialog.Root


### PR DESCRIPTION
Because

- can not filter their existing resource when create resource directly on pipeline builder

This commit

- fix user can not filter their existing resource when create resource directly on pipeline builder
