### PR TITLE
fix(toolkit): fix the wrong component configuration field description for instill model

### DIFF
--- a/packages/toolkit/src/view/ai/AIForm.tsx
+++ b/packages/toolkit/src/view/ai/AIForm.tsx
@@ -1240,7 +1240,7 @@ export const AIForm = (props: AIFormProps) => {
                     </Input.Root>
                   </Form.Control>
                   <Form.Description>
-                    ID of the Instill Model&apos;s model to be used.
+                    Namespace of the Instill Model&apos;s model to be used.
                   </Form.Description>
                   <Form.Message />
                 </Form.Item>
@@ -1273,7 +1273,7 @@ export const AIForm = (props: AIFormProps) => {
                     </Input.Root>
                   </Form.Control>
                   <Form.Description>
-                    Namespace of the Instill Model&apos;s model to be used.
+                    ID of the Instill Model&apos;s model to be used.
                   </Form.Description>
                   <Form.Message />
                 </Form.Item>


### PR DESCRIPTION
Because

- component configuration field description for instill model is wrong

This commit

- fix the wrong component configuration field description for instill model
