### PR TITLE
fix(pipeline-builder): fix a bug when create fields on the end operator will wrongly use the key from the previous edited field

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.3-rc.58",
+  "version": "0.68.3-rc.60",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/EndNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/EndNode.tsx
@@ -196,12 +196,18 @@ export const EndNode = ({ data, id }: NodeProps<EndNodeData>) => {
                   variant="tertiaryGrey"
                   size="sm"
                   className="!px-2 !py-2"
+                  type="button"
                   onClick={() => {
                     setEnableEdit(!enableEdit);
-                    form.reset();
+                    setPrevFieldKey(null);
+                    form.reset({
+                      title: "",
+                      key: "",
+                      value: "",
+                    });
                   }}
                 >
-                  <Icons.ArrowLeft className="m-auto h-4 w-4 stroke-slate-500" />
+                  <Icons.ArrowLeft className="m-auto h-4 w-4 stroke-semantic-fg-secondary" />
                 </Button>
                 <div>
                   <Button variant="primary" type="submit" size="sm">

--- a/packages/toolkit/src/view/pipeline-builder/use-node-output-fields/NumberField.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/use-node-output-fields/NumberField.tsx
@@ -1,5 +1,5 @@
 import { Nullable } from "../../../lib";
-import { ConnectorNodeFieldRoot } from "./FieldRoot";
+import { ConnectorNodeFieldRoot, EndNodeFieldRoot } from "./FieldRoot";
 
 export type NumberFieldProps = {
   nodeType: "end" | "connector";
@@ -13,7 +13,7 @@ export const NumberField = (props: NumberFieldProps) => {
   if (nodeType === "connector") {
     return (
       <ConnectorNodeFieldRoot title={title} key={`${title}-field`}>
-        <div className="flex break-all text-semantic-fg-primary product-body-text-4-regular">
+        <div className="flex rounded-sm break-all text-semantic-fg-primary product-body-text-4-regular">
           {number}
         </div>
       </ConnectorNodeFieldRoot>
@@ -21,13 +21,10 @@ export const NumberField = (props: NumberFieldProps) => {
   }
 
   return (
-    <div key={`${title}-field`} className="flex w-full flex-col space-y-2">
-      <p className="text-semantic-fg-primary product-body-text-3-semibold">
-        {title}
-      </p>
-      <div className="flex max-w-[200px] break-all border border-semantic-bg-line bg-semantic-bg-primary px-[9px] py-1.5 text-semantic-fg-primary product-body-text-4-regular">
+    <EndNodeFieldRoot title={title} key={`${title}-field`}>
+      <div className="flex rounded-sm max-w-[200px] break-all border border-semantic-bg-line bg-semantic-bg-primary px-[9px] py-1.5 text-semantic-fg-primary product-body-text-4-regular">
         {number}
       </div>
-    </div>
+    </EndNodeFieldRoot>
   );
 };

--- a/packages/toolkit/src/view/pipeline-builder/use-node-output-fields/NumbersField.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/use-node-output-fields/NumbersField.tsx
@@ -17,7 +17,7 @@ export const NumbersField = (props: NumbersFieldProps) => {
           {numbers?.map((number) => (
             <div
               key={`${title}-${number}-field`}
-              className="break-all text-semantic-fg-primary product-body-text-4-regular"
+              className="break-all rounded-sm text-semantic-fg-primary product-body-text-4-regular"
             >
               {number}
             </div>
@@ -33,7 +33,7 @@ export const NumbersField = (props: NumbersFieldProps) => {
         {numbers?.map((number) => (
           <div
             key={`${title}-${number}-field`}
-            className="flex break-all border border-semantic-bg-line bg-semantic-bg-primary px-[9px] py-1.5 text-semantic-fg-primary product-body-text-4-regular"
+            className="flex break-all rounded-sm border border-semantic-bg-line bg-semantic-bg-primary px-[9px] py-1.5 text-semantic-fg-primary product-body-text-4-regular"
           >
             {number}
           </div>

--- a/packages/toolkit/src/view/pipeline-builder/use-node-output-fields/TextField.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/use-node-output-fields/TextField.tsx
@@ -15,7 +15,7 @@ export const TextField = (props: TextFieldProps) => {
     return (
       <ConnectorNodeFieldRoot title={title} key={`${title}-field`}>
         <div className="flex p-2 relative w-full rounded-sm border border-semantic-bg-line flex-row justify-between gap-x-2">
-          <pre className="min-h-[16px] whitespace-pre-line max-w-[480px] breal-all flex flex-1 text-semantic-fg-primary product-body-text-4-regular">
+          <pre className="min-h-[36px] whitespace-pre-line max-w-[480px] breal-all flex flex-1 text-semantic-fg-primary product-body-text-4-regular">
             {text}
           </pre>
           {text ? (
@@ -32,7 +32,7 @@ export const TextField = (props: TextFieldProps) => {
   return (
     <EndNodeFieldRoot title={title} key={`${title}-field`}>
       <div className="flex p-2 relative w-full rounded-sm border border-semantic-bg-line flex-row justify-between gap-x-2">
-        <pre className="min-h-[16px] whitespace-pre-line max-w-[480px] breal-all flex flex-1 text-semantic-fg-primary product-body-text-4-regular">
+        <pre className="min-h-[36px] whitespace-pre-line max-w-[480px] breal-all flex flex-1 text-semantic-fg-primary product-body-text-4-regular">
           {text}
         </pre>
         {text ? (


### PR DESCRIPTION
Because

- when create fields on the end operator will wrongly use the key from the previous edited field

This commit

- Fix a bug when create fields on the end operator will wrongly use the key from the previous edited field
