### PR TITLE
fix(pipeline-builder): fix data connector can't have multiple free-form fields

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.68.3-rc.69",
+  "version": "0.68.3-rc.71",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/connector-node/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/connector-node/ConnectorNode.tsx
@@ -171,6 +171,8 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
     return getPropertiesFromOpenAPISchema(inputSchema);
   }, [inputSchema]);
 
+  console.log(id, inputProperties);
+
   const collapsedInputProperties = React.useMemo(() => {
     if (exapndInputs) return inputProperties;
     return inputProperties.slice(0, 3);
@@ -266,6 +268,7 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
               input: {
                 ...node.data.component.configuration.input,
                 data: {
+                  ...node.data.component.configuration.input.data,
                   [formData.key]: formData.value,
                 },
               },
@@ -609,7 +612,7 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
                   </Button>
                 </div>
               </div>
-              <div className="flex flex-col space-y-3">
+              <div className="mb-3 flex flex-col space-y-3">
                 <Form.Field
                   control={dataConnectorInputForm.control}
                   name="key"


### PR DESCRIPTION
Because

- data connector can't have multiple free-form fields

This commit

- fix data connector can't have multiple free-form fields